### PR TITLE
Fix: uv venv missing pip - add --seed flag

### DIFF
--- a/internal/bootstrap/code_deploy.go
+++ b/internal/bootstrap/code_deploy.go
@@ -271,7 +271,8 @@ func createVirtualEnv(ctx context.Context, repoPath, venvPath string, logger Log
 	// Try uv first (faster, doesn't require ensurepip)
 	if uvCmd := findUV(); uvCmd != "" {
 		logger.Info("Creating virtualenv at %s using uv", venvPath)
-		cmd := exec.CommandContext(ctx, uvCmd, "venv", venvPath)
+		// Use --seed to include pip in the venv (required for pip install later)
+		cmd := exec.CommandContext(ctx, uvCmd, "venv", "--seed", venvPath)
 		cmd.Dir = repoPath
 		if output, err := cmd.CombinedOutput(); err == nil {
 			// Verify the python executable exists


### PR DESCRIPTION
## Problem

When using `uv venv` without `--seed`, pip is not included in the virtual environment. This causes the subsequent `python -m pip install -r requirements.txt` to fail with:

```
.venv/bin/python: No module named pip
```

## Solution

Add `--seed` flag to `uv venv` command to ensure pip is installed in the virtual environment.

## Testing

Tested on Ubuntu 24.04 with:
- uv 0.6.x
- Python 3.13.7
- runqy-server (sqlite mode)

Before fix:
```
[INFO] Virtualenv created successfully with uv
[WARN] Failed to upgrade pip: exit status 1
Output: .venv/bin/python: No module named pip
Bootstrap failed: pip install failed
```

After fix:
```
[INFO] Virtualenv created successfully with uv
[INFO] Dependencies installed successfully
```

---

🦊 *First contribution by Akari*