### PR TITLE
feat(docker): add build tools for C/C++ compilation

### DIFF
--- a/Dockerfile.inference
+++ b/Dockerfile.inference
@@ -1,5 +1,5 @@
-# Inference-ready image with Python3, pip, virtualenv
-# User installs their own ML libraries via bootstrap
+# Inference-ready image with Python3, pip, virtualenv, and build tools
+# Supports workers that require compilation (llama-cpp-python, etc.)
 
 FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime
 
@@ -13,6 +13,10 @@ RUN apt-get update && \
     curl \
     wget \
     ca-certificates \
+    # Build tools for C/C++ compilation (llama-cpp-python, etc.)
+    build-essential \
+    cmake \
+    ninja-build \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Add `build-essential`, `cmake`, and `ninja-build` to the inference Docker image to support workers that require C/C++ compilation.

## Motivation

When deploying LLM workers using `llama-cpp-python`, the current image fails because it lacks compilers:

```
CMake Error: CMAKE_C_COMPILER not set
CMake Error: CMAKE_CXX_COMPILER not set
```

## Changes

- Added `build-essential` (gcc, g++, make)
- Added `cmake` for build configuration
- Added `ninja-build` for faster builds

## Testing

Tested with a Dolphin LLM worker using llama-cpp-python on Vast.ai.

## Size Impact

Adds ~200MB to the image, but enables a much broader range of ML workers without requiring custom images.