### PR TITLE
fix: revert ZRem back to SRem for worker deregister

### DIFF
--- a/heartbeat.go
+++ b/heartbeat.go
@@ -296,7 +296,7 @@ func (h *heartbeat) deregister(ctx context.Context) {
 	rdb := h.rdb
 	h.mu.RUnlock()
 
-	rdb.ZRem(ctx, keyWorkers, h.workerID)
+	rdb.SRem(ctx, keyWorkers, h.workerID)
 
 	workerKey := fmt.Sprintf(keyWorkerData, h.workerID)
 	rdb.HSet(ctx, workerKey, "status", "stopped")


### PR DESCRIPTION
The server registers workers with `SADD` (Redis SET), so deregister must use `SRem` (not `ZRem` which targets sorted sets).

`ZRem` on a regular set is a silent no-op, leaving ghost workers in the registry.

One-line change in `heartbeat.go:299`.