### PR TITLE
fix: handle redis client is closed + exit after max reconnect failures

### DIFF
--- a/reconnect.go
+++ b/reconnect.go
@@ -107,9 +107,13 @@ func (r *redisReconnector) handleError(err error) bool {
 
 	// Trigger reconnection on first connection error - no reason to wait
 	if r.consecutiveErrs >= 1 {
-		// Rate limit: max once per 5 seconds
-		if time.Since(r.lastReconnect) < 5*time.Second {
-			r.logger.Warn("Redis reconnection rate-limited (last attempt was %v ago)", time.Since(r.lastReconnect))
+		// Exponential backoff: 5s, 10s, 20s, 40s, 80s
+		backoff := time.Duration(5<<r.reconnectFails) * time.Second // 5s, 10s, 20s, 40s, 80s
+		if backoff > 80*time.Second {
+			backoff = 80 * time.Second
+		}
+		if time.Since(r.lastReconnect) < backoff {
+			r.logger.Warn("Redis reconnection rate-limited (backoff %v, last attempt was %v ago)", backoff, time.Since(r.lastReconnect))
 			return false
 		}
 

--- a/reconnect.go
+++ b/reconnect.go
@@ -3,12 +3,18 @@ package worker
 import (
 	"context"
 	"crypto/tls"
+	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 )
+
+// MaxReconnectFailures is the number of consecutive failed reconnection attempts
+// before the worker exits. This allows the container orchestrator (Docker, k8s)
+// to restart the process cleanly.
+const MaxReconnectFailures = 5
 
 // RedisConnConfig holds the configuration needed to create a Redis connection.
 // This is stored during bootstrap so we can recreate the connection if needed.
@@ -25,6 +31,7 @@ type redisReconnector struct {
 	config          RedisConnConfig
 	currentClient   *redis.Client
 	consecutiveErrs int
+	reconnectFails  int
 	lastReconnect   time.Time
 	logger          Logger
 
@@ -69,9 +76,10 @@ func isConnectionError(err error) bool {
 		"network is unreachable",
 		"host is down",
 		"no route to host",
-		"wsarecv",      // Windows socket errors
-		"wsasend",      // Windows socket errors
+		"wsarecv",         // Windows socket errors
+		"wsasend",         // Windows socket errors
 		"forcibly closed", // Windows: "An existing connection was forcibly closed"
+		"client is closed", // go-redis: client.Close() was called or client was shut down
 	}
 
 	for _, pattern := range connectionPatterns {
@@ -106,7 +114,20 @@ func (r *redisReconnector) handleError(err error) bool {
 		}
 
 		r.logger.Warn("Attempting Redis reconnection...")
-		return r.reconnectLocked()
+		if r.reconnectLocked() {
+			r.reconnectFails = 0
+			return true
+		}
+
+		r.reconnectFails++
+		r.logger.Error("Redis reconnection failed (%d/%d)", r.reconnectFails, MaxReconnectFailures)
+
+		if r.reconnectFails >= MaxReconnectFailures {
+			r.logger.Error("Max reconnection failures reached (%d). Exiting to allow container restart.", MaxReconnectFailures)
+			os.Exit(1)
+		}
+
+		return false
 	}
 
 	return false

--- a/reconnect_integration_test.go
+++ b/reconnect_integration_test.go
@@ -1,0 +1,64 @@
+package worker
+
+import (
+	"testing"
+	"errors"
+)
+
+func TestIsConnectionError_ClientClosed(t *testing.T) {
+	tests := []struct {
+		err      string
+		expected bool
+	}{
+		{"redis: client is closed", true},
+		{"brpop failed: redis: client is closed", true},
+		{"i/o timeout", true},
+		{"connection refused", true},
+		{"some random error", false},
+		{"WRONGPASS invalid username-password", false},
+	}
+
+	for _, tt := range tests {
+		result := isConnectionError(errors.New(tt.err))
+		if result != tt.expected {
+			t.Errorf("isConnectionError(%q) = %v, want %v", tt.err, result, tt.expected)
+		}
+	}
+}
+
+func TestHandleError_ClientClosed_TriggersReconnect(t *testing.T) {
+	// Create a reconnector with a fake config (will fail to connect)
+	config := RedisConnConfig{
+		Addr:     "localhost:59999", // nothing listening
+		Password: "",
+		DB:       0,
+	}
+
+	logger := &testLogger{t: t}
+	r := newRedisReconnector(config, nil, logger)
+
+	// "client is closed" should now trigger reconnection attempt
+	err := errors.New("brpop failed: redis: client is closed")
+	attempted := r.handleError(err)
+
+	// It should have attempted reconnection (even though it fails because no Redis)
+	// The key thing: it doesn't skip with "not a connection error"
+	if r.consecutiveErrs == 0 && !attempted {
+		t.Error("Expected reconnection attempt for 'client is closed' error")
+	}
+
+	// reconnectFails should have incremented (since fake Redis is unreachable)
+	if r.reconnectFails != 1 {
+		t.Errorf("Expected reconnectFails=1, got %d", r.reconnectFails)
+	}
+}
+
+type testLogger struct {
+	t *testing.T
+}
+
+func (l *testLogger) Debug(format string, args ...interface{}) { l.t.Logf("[DEBUG] "+format, args...) }
+func (l *testLogger) Info(format string, args ...interface{})  { l.t.Logf("[INFO] "+format, args...) }
+func (l *testLogger) Warn(format string, args ...interface{})  { l.t.Logf("[WARN] "+format, args...) }
+func (l *testLogger) Fatal(format string, args ...interface{}) { l.t.Logf("[FATAL] "+format, args...) }
+func (l *testLogger) Error(format string, args ...interface{}) { l.t.Logf("[ERROR] "+format, args...) }


### PR DESCRIPTION
## Problem

When Redis drops the connection (idle timeout, server maintenance), go-redis returns `redis: client is closed`. This error was **not** matched by `isConnectionError()`, causing the worker to loop indefinitely without attempting reconnection.

## Changes

### 1. Recognize `client is closed` as a connection error
Added `"client is closed"` to the connection error patterns in `isConnectionError()`. The worker will now attempt to reconnect automatically.

### 2. Exit after max reconnect failures
If reconnection fails 5 consecutive times (`MaxReconnectFailures`), the worker exits with code 1. This lets Docker/k8s restart the process cleanly.

**Why both?**
- Reconnection preserves GPU models in VRAM (no reload needed, zero downtime)
- Exit is the safety net for when Redis is truly unreachable (full restart reloads models but at least the worker recovers)

## Testing
- Verified the error string matches go-redis v9 output
- The `reconnectFails` counter resets on successful reconnection