### PR TITLE
feat: git pull on restart to update deployed worker code

### DIFF
--- a/internal/bootstrap/code_deploy.go
+++ b/internal/bootstrap/code_deploy.go
@@ -74,6 +74,16 @@ func DeployCode(ctx context.Context, config Config, spec DeploymentConfig, logge
 	}, nil
 }
 
+
+// gitEnv builds the environment variables for git operations (SSH key or token auth).
+func gitEnv(config Config, spec DeploymentConfig) []string {
+	if config.GitSSHKey != "" {
+		sshCmd := fmt.Sprintf("ssh -i %s -o StrictHostKeyChecking=no", config.GitSSHKey)
+		return append(os.Environ(), "GIT_SSH_COMMAND="+sshCmd)
+	}
+	return os.Environ()
+}
+
 // gitClone clones the repository or reuses existing deployment.
 // If spec.CodePath is set, uses sparse checkout to only download that subdirectory.
 func gitClone(ctx context.Context, deployDir string, spec DeploymentConfig, config Config, logger Logger) (string, error) {
@@ -83,7 +93,20 @@ func gitClone(ctx context.Context, deployDir string, spec DeploymentConfig, conf
 		// Directory exists - check for .git
 		gitDir := filepath.Join(deployDir, ".git")
 		if _, err := os.Stat(gitDir); err == nil {
-			logger.Info("Using existing deployment at %s", deployDir)
+			logger.Info("Existing deployment found at %s, pulling latest changes...", deployDir)
+
+			// Pull latest changes to ensure worker runs up-to-date code
+			pullArgs := []string{"pull", "--ff-only"}
+			pullCmd := exec.CommandContext(ctx, "git", pullArgs...)
+			pullCmd.Dir = deployDir
+			pullCmd.Env = gitEnv(config, spec)
+
+			if pullOutput, pullErr := pullCmd.CombinedOutput(); pullErr != nil {
+				logger.Warn("Git pull failed (continuing with existing code): %v\nOutput: %s", pullErr, string(pullOutput))
+			} else {
+				logger.Info("Git pull successful")
+			}
+
 			return deployDir, nil
 		}
 		// Directory exists but no .git - error


### PR DESCRIPTION
## Problem

When a worker restarts, if the deployment directory already exists (`.git` present), it skips the clone entirely and reuses stale code. The only way to update was to manually delete the deployment directory.

## Fix

Add `git pull --ff-only` when an existing deployment is found. This fetches the latest changes from the branch before reusing the directory.

**Non-blocking:** If the pull fails (network issue, merge conflict), the worker logs a warning and continues with the existing code. No data loss, no stuck worker.

## Before/After

**Before:** Worker restart → "Using existing deployment" → stale code

**After:** Worker restart → `git pull --ff-only` → latest code → run

## Testing

- All existing tests pass
- Build passes