### PR TITLE
fix(worker): recover orphaned active tasks and fix multi-worker shutdown

### DIFF
--- a/config.go
+++ b/config.go
@@ -44,6 +44,13 @@ type Config struct {
 	ShutdownTimeout   time.Duration // Time to wait for graceful shutdown (default: 8s)
 	CompletedTaskTTL  time.Duration // TTL for completed/failed task keys in Redis (default: 24h, 0 = no expiry)
 
+	// Lease settings
+	// A task's lease is set at dequeue and periodically renewed by the worker while it
+	// is being processed. If the worker dies, the lease expires and the lease recoverer
+	// reclaims the task. LeaseDuration must be comfortably larger than LeaseExtendInterval.
+	LeaseDuration       time.Duration // How long a lease is valid before it must be renewed (default: 2m)
+	LeaseExtendInterval time.Duration // How often in-flight leases are renewed (default: LeaseDuration/2)
+
 	// Logger (optional, defaults to standard logger)
 	Logger Logger
 
@@ -76,6 +83,11 @@ func DefaultConfig() Config {
 		MaxRetry:        25,
 		ShutdownTimeout:  8 * time.Second,
 		CompletedTaskTTL: 24 * time.Hour,
+
+		// Lease defaults
+		LeaseDuration:       2 * time.Minute,
+		LeaseExtendInterval: 1 * time.Minute,
+
 		Logger:          NewStdLogger(),
 		Recovery:        DefaultRecoveryConfig(),
 	}

--- a/config_yaml.go
+++ b/config_yaml.go
@@ -178,6 +178,18 @@ func loadConfigFromEnv() Config {
 		}
 	}
 
+	// Lease settings
+	if lease := os.Getenv("RUNQY_LEASE_DURATION"); lease != "" {
+		if d, err := time.ParseDuration(lease); err == nil && d > 0 {
+			cfg.LeaseDuration = d
+		}
+	}
+	if interval := os.Getenv("RUNQY_LEASE_EXTEND_INTERVAL"); interval != "" {
+		if d, err := time.ParseDuration(interval); err == nil && d > 0 {
+			cfg.LeaseExtendInterval = d
+		}
+	}
+
 	// Bootstrap settings
 	if retries := os.Getenv("RUNQY_BOOTSTRAP_RETRIES"); retries != "" {
 		if n, err := strconv.Atoi(retries); err == nil && n > 0 {

--- a/hardening_test.go
+++ b/hardening_test.go
@@ -145,6 +145,33 @@ func newTestProcessor(cfg Config) *processor {
 		done:          make(chan struct{}),
 		stopping:      make(chan struct{}),
 		logger:        cfg.Logger,
+		inflight:      make(map[string]string),
+		leaseDone:     make(chan struct{}),
+	}
+}
+
+// TestProcessorInflightRegistry verifies the in-flight task registry that backs
+// lease extension and shutdown requeue: tracking/untracking, and that
+// snapshotInflight returns an independent copy (so the shutdown requeue can
+// iterate it safely while task goroutines untrack concurrently).
+func TestProcessorInflightRegistry(t *testing.T) {
+	p := newTestProcessor(DefaultConfig())
+
+	p.trackInflight("t1", "q.default")
+	p.trackInflight("t2", "q.high")
+
+	snap := p.snapshotInflight()
+	if len(snap) != 2 || snap["t1"] != "q.default" || snap["t2"] != "q.high" {
+		t.Fatalf("unexpected snapshot: %v", snap)
+	}
+
+	// The snapshot must be a copy: untracking after taking it must not mutate it.
+	p.untrackInflight("t1")
+	if _, ok := snap["t1"]; !ok {
+		t.Fatal("snapshot should be an independent copy, but t1 disappeared after untrack")
+	}
+	if s2 := p.snapshotInflight(); len(s2) != 1 || s2["t2"] != "q.high" {
+		t.Fatalf("after untracking t1, expected only t2, got: %v", s2)
 	}
 }
 

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -299,7 +299,7 @@ func (h *heartbeat) deregister(ctx context.Context) {
 	rdb := h.rdb
 	h.mu.RUnlock()
 
-	rdb.SRem(ctx, keyWorkers, h.workerID)
+	rdb.ZRem(ctx, keyWorkers, h.workerID)
 
 	workerKey := fmt.Sprintf(keyWorkerData, h.workerID)
 	rdb.HSet(ctx, workerKey, "status", "stopped")

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -256,8 +256,10 @@ func appendVarint(buf []byte, val uint64) []byte {
 
 // Dequeue attempts to dequeue a task from the given queues using BRPOP.
 // This is compatible with asynq's list-based pending queue.
+// leaseDuration sets how long the task's lease is valid before it must be
+// renewed (see ExtendLease); the worker renews it periodically while processing.
 // Returns nil if no task is available.
-func (r *Client) Dequeue(ctx context.Context, queues []string) (*TaskData, error) {
+func (r *Client) Dequeue(ctx context.Context, queues []string, leaseDuration time.Duration) (*TaskData, error) {
 	// Build list of pending queue keys
 	keys := make([]string, len(queues))
 	for i, q := range queues {
@@ -334,7 +336,10 @@ func (r *Client) Dequeue(ctx context.Context, queues []string) (*TaskData, error
 	// Atomically: move task to active queue, add to lease tracking, update state
 	activeKey := fmt.Sprintf(KeyActive, queueName)
 	leaseKey := fmt.Sprintf(KeyLease, queueName)
-	leaseExpiration := float64(time.Now().Add(30 * time.Minute).Unix())
+	if leaseDuration <= 0 {
+		leaseDuration = 2 * time.Minute
+	}
+	leaseExpiration := float64(time.Now().Add(leaseDuration).Unix())
 
 	activateScript := redis.NewScript(`
 		redis.call("LPUSH", KEYS[1], ARGV[1])
@@ -347,12 +352,12 @@ func (r *Client) Dequeue(ctx context.Context, queues []string) (*TaskData, error
 		[]string{activeKey, leaseKey, taskKey},
 		taskID, leaseExpiration, StateActive,
 	).Err(); err != nil {
-		r.Logger.Error("Lua activate script failed for task %s, falling back to non-atomic: %v", taskID, err)
-		// Fallback to non-atomic operations
-		r.Rdb.LPush(ctx, activeKey, taskID)
-		r.Rdb.ZAdd(ctx, leaseKey, redis.Z{Score: leaseExpiration, Member: taskID})
-		r.Rdb.HSet(ctx, taskKey, FieldState, StateActive)
-		r.Rdb.HDel(ctx, taskKey, FieldPendingSince)
+		r.Logger.Error("Lua activate script failed for task %s, returning to pending: %v", taskID, err)
+		// Push back to pending so another worker (or this one) can pick it up.
+		// Do NOT push to active — that would risk duplicates.
+		pendingKey := fmt.Sprintf(KeyPending, queueName)
+		r.Rdb.RPush(ctx, pendingKey, taskID)
+		return nil, fmt.Errorf("activate script failed for task %s: %w", taskID, err)
 	}
 
 	taskData := &TaskData{
@@ -368,6 +373,20 @@ func (r *Client) Dequeue(ctx context.Context, queues []string) (*TaskData, error
 	return taskData, nil
 }
 
+// completeCmd atomically removes a task from active/lease and marks it as completed.
+// KEYS[1] = activeKey, KEYS[2] = leaseKey, KEYS[3] = completedKey, KEYS[4] = taskKey
+// ARGV[1] = taskID, ARGV[2] = now (unix), ARGV[3] = state, ARGV[4] = ttl (seconds, 0 = no expiry)
+var completeCmd = redis.NewScript(`
+redis.call("LREM", KEYS[1], 0, ARGV[1])
+redis.call("ZREM", KEYS[2], ARGV[1])
+redis.call("ZADD", KEYS[3], ARGV[2], ARGV[1])
+redis.call("HSET", KEYS[4], "state", ARGV[3], "completed_at", ARGV[2])
+if tonumber(ARGV[4]) > 0 then
+    redis.call("EXPIRE", KEYS[4], ARGV[4])
+end
+return 1
+`)
+
 // Complete marks a task as completed and removes it from active queue.
 // Results are already written to the task hash by TaskResultWriter.
 // If ttl > 0, sets an expiry on the task hash key so it is automatically cleaned up.
@@ -379,13 +398,8 @@ func (r *Client) Complete(ctx context.Context, taskID string, queueName string, 
 
 	now := time.Now().Unix()
 
-	// Remove from active queue (List) and lease tracking (Sorted Set)
-	r.Rdb.LRem(ctx, activeKey, 1, taskID)
-	r.Rdb.ZRem(ctx, leaseKey, taskID)
-
-	// Update the protobuf msg field with completed_at timestamp (for asynq inspector compatibility).
-	// Append field 13 (completed_at, varint) to the existing protobuf blob.
-	// Protobuf allows appending fields — the last value for a scalar field wins.
+	// Best-effort: update protobuf msg field with completed_at timestamp (for asynq inspector compatibility).
+	// This is non-critical; the hash fields are authoritative.
 	if msgData, err := r.Rdb.HGet(ctx, taskKey, FieldMsg).Result(); err == nil {
 		var extra []byte
 		extra = append(extra, (13<<3)|0) // field 13, wire type 0 (varint)
@@ -393,22 +407,44 @@ func (r *Client) Complete(ctx context.Context, taskID string, queueName string, 
 		r.Rdb.HSet(ctx, taskKey, FieldMsg, string(append([]byte(msgData), extra...)))
 	}
 
-	// Update task hash: state and completed_at
-	r.Rdb.HSet(ctx, taskKey,
-		FieldState, StateCompleted,
-		FieldCompletedAt, now,
-	)
-
-	// Add to completed sorted set with Unix timestamp as score
-	r.Rdb.ZAdd(ctx, completedKey, redis.Z{Score: float64(now), Member: taskID})
-
-	// Set TTL on the task hash key so completed tasks are automatically cleaned up
+	// Atomic: remove from active + lease, add to completed, update state
+	ttlSecs := int64(0)
 	if ttl > 0 {
-		r.Rdb.Expire(ctx, taskKey, ttl)
+		ttlSecs = int64(ttl.Seconds())
+	}
+	if err := completeCmd.Run(ctx, r.Rdb,
+		[]string{activeKey, leaseKey, completedKey, taskKey},
+		taskID, now, StateCompleted, ttlSecs,
+	).Err(); err != nil {
+		return fmt.Errorf("complete script failed for task %s: %w", taskID, err)
 	}
 
 	return nil
 }
+
+// retryWithDelayCmd atomically removes from active/lease, adds to retry sorted set.
+// KEYS[1] = activeKey, KEYS[2] = leaseKey, KEYS[3] = retryKey, KEYS[4] = taskKey
+// ARGV[1] = taskID, ARGV[2] = retryAt (unix), ARGV[3] = now (unix)
+var retryWithDelayCmd = redis.NewScript(`
+redis.call("LREM", KEYS[1], 0, ARGV[1])
+redis.call("ZREM", KEYS[2], ARGV[1])
+redis.call("ZADD", KEYS[3], ARGV[2], ARGV[1])
+redis.call("HINCRBY", KEYS[4], "retried", 1)
+redis.call("HSET", KEYS[4], "state", "retry", "last_failed_at", ARGV[3])
+return 1
+`)
+
+// retryImmediateCmd atomically removes from active/lease, pushes directly to pending.
+// KEYS[1] = activeKey, KEYS[2] = leaseKey, KEYS[3] = pendingKey, KEYS[4] = taskKey
+// ARGV[1] = taskID, ARGV[2] = now (unix)
+var retryImmediateCmd = redis.NewScript(`
+redis.call("LREM", KEYS[1], 0, ARGV[1])
+redis.call("ZREM", KEYS[2], ARGV[1])
+redis.call("LPUSH", KEYS[3], ARGV[1])
+redis.call("HINCRBY", KEYS[4], "retried", 1)
+redis.call("HSET", KEYS[4], "state", "pending", "last_failed_at", ARGV[2])
+return 1
+`)
 
 // Retry re-queues a task for retry using the retry sorted set.
 func (r *Client) Retry(ctx context.Context, task *TaskData, queueName string, delay time.Duration) error {
@@ -420,12 +456,7 @@ func (r *Client) Retry(ctx context.Context, task *TaskData, queueName string, de
 
 	now := time.Now()
 
-	// Remove from active queue (List) and lease tracking (Sorted Set)
-	r.Rdb.LRem(ctx, activeKey, 1, task.ID)
-	r.Rdb.ZRem(ctx, leaseKey, task.ID)
-
-	// Update the protobuf msg field with incremented retry count (for asynqmon compatibility).
-	// If the msg field is missing, create it from the task data.
+	// Best-effort: update protobuf msg field with incremented retry count (for asynqmon compatibility).
 	if msgData, err := r.Rdb.HGet(ctx, taskKey, FieldMsg).Result(); err == nil {
 		if asynqMsg, err := parseAsynqMessage([]byte(msgData)); err == nil {
 			asynqMsg.Retried++
@@ -443,22 +474,22 @@ func (r *Client) Retry(ctx context.Context, task *TaskData, queueName string, de
 		r.Rdb.HSet(ctx, taskKey, FieldMsg, string(msg))
 	}
 
-	// Increment retry count in hash field and update state
-	r.Rdb.HIncrBy(ctx, taskKey, FieldRetried, 1)
-	r.Rdb.HSet(ctx, taskKey,
-		FieldState, StateRetry,
-		FieldLastFailedAt, now.Unix(),
-	)
-
+	// Atomic: remove from active + lease, move to retry or pending
 	if delay > 0 {
-		// Add to retry sorted set with scheduled time as score.
-		// The retryForwarder will move it to pending when the time comes.
 		retryAt := float64(now.Add(delay).Unix())
-		r.Rdb.ZAdd(ctx, retryKey, redis.Z{Score: retryAt, Member: task.ID})
+		if err := retryWithDelayCmd.Run(ctx, r.Rdb,
+			[]string{activeKey, leaseKey, retryKey, taskKey},
+			task.ID, retryAt, now.Unix(),
+		).Err(); err != nil {
+			return fmt.Errorf("retry script failed for task %s: %w", task.ID, err)
+		}
 	} else {
-		// No delay, push directly to pending
-		r.Rdb.LPush(ctx, pendingKey, task.ID)
-		r.Rdb.HSet(ctx, taskKey, FieldState, StatePending)
+		if err := retryImmediateCmd.Run(ctx, r.Rdb,
+			[]string{activeKey, leaseKey, pendingKey, taskKey},
+			task.ID, now.Unix(),
+		).Err(); err != nil {
+			return fmt.Errorf("retry-immediate script failed for task %s: %w", task.ID, err)
+		}
 	}
 
 	return nil
@@ -523,6 +554,20 @@ func (r *Client) ForwardReady(ctx context.Context, queues []string) (int, error)
 	return total, nil
 }
 
+// failCmd atomically removes from active/lease and archives a task.
+// KEYS[1] = activeKey, KEYS[2] = leaseKey, KEYS[3] = archivedKey, KEYS[4] = taskKey
+// ARGV[1] = taskID, ARGV[2] = now (unix), ARGV[3] = errMsg, ARGV[4] = ttl (seconds, 0 = no expiry)
+var failCmd = redis.NewScript(`
+redis.call("LREM", KEYS[1], 0, ARGV[1])
+redis.call("ZREM", KEYS[2], ARGV[1])
+redis.call("ZADD", KEYS[3], ARGV[2], ARGV[1])
+redis.call("HSET", KEYS[4], "state", "archived", "error_msg", ARGV[3], "last_failed_at", ARGV[2])
+if tonumber(ARGV[4]) > 0 then
+    redis.call("EXPIRE", KEYS[4], ARGV[4])
+end
+return 1
+`)
+
 // Fail marks a task as permanently failed (archived).
 // If ttl > 0, sets an expiry on the task hash key so it is automatically cleaned up.
 func (r *Client) Fail(ctx context.Context, task *TaskData, queueName string, errMsg string, ttl time.Duration) error {
@@ -533,12 +578,7 @@ func (r *Client) Fail(ctx context.Context, task *TaskData, queueName string, err
 
 	now := time.Now().Unix()
 
-	// Remove from active queue (List) and lease tracking (Sorted Set)
-	r.Rdb.LRem(ctx, activeKey, 1, task.ID)
-	r.Rdb.ZRem(ctx, leaseKey, task.ID)
-
-	// Ensure the msg protobuf field exists for asynq inspector compatibility.
-	// If missing, create it from the task data we have.
+	// Best-effort: ensure protobuf msg field exists for asynq inspector compatibility.
 	if exists, _ := r.Rdb.HExists(ctx, taskKey, FieldMsg).Result(); !exists {
 		msg := encodeAsynqMessage(&asynqTaskMessage{
 			Type:     task.Type,
@@ -550,19 +590,16 @@ func (r *Client) Fail(ctx context.Context, task *TaskData, queueName string, err
 		r.Rdb.HSet(ctx, taskKey, FieldMsg, string(msg))
 	}
 
-	// Update task hash: state, error message, and last failed timestamp
-	r.Rdb.HSet(ctx, taskKey,
-		FieldState, StateArchived,
-		FieldErrorMsg, errMsg,
-		FieldLastFailedAt, now,
-	)
-
-	// Add to archived sorted set with Unix timestamp as score
-	r.Rdb.ZAdd(ctx, archivedKey, redis.Z{Score: float64(now), Member: task.ID})
-
-	// Set TTL on the task hash key so archived tasks are automatically cleaned up
+	// Atomic: remove from active + lease, add to archived, update state
+	ttlSecs := int64(0)
 	if ttl > 0 {
-		r.Rdb.Expire(ctx, taskKey, ttl)
+		ttlSecs = int64(ttl.Seconds())
+	}
+	if err := failCmd.Run(ctx, r.Rdb,
+		[]string{activeKey, leaseKey, archivedKey, taskKey},
+		task.ID, now, errMsg, ttlSecs,
+	).Err(); err != nil {
+		return fmt.Errorf("fail script failed for task %s: %w", task.ID, err)
 	}
 
 	return nil
@@ -578,6 +615,16 @@ func (r *Client) GetRedisClient() *redis.Client {
 	return r.Rdb
 }
 
+// cleanupActiveCmd atomically removes from active/lease and deletes the task hash.
+// KEYS[1] = activeKey, KEYS[2] = leaseKey, KEYS[3] = taskKey
+// ARGV[1] = taskID
+var cleanupActiveCmd = redis.NewScript(`
+redis.call("LREM", KEYS[1], 0, ARGV[1])
+redis.call("ZREM", KEYS[2], ARGV[1])
+redis.call("DEL", KEYS[3])
+return 1
+`)
+
 // CleanupActive removes a task from active queue without storing completion data.
 // Used when redis_storage is disabled.
 func (r *Client) CleanupActive(ctx context.Context, taskID string, queueName string) error {
@@ -585,12 +632,12 @@ func (r *Client) CleanupActive(ctx context.Context, taskID string, queueName str
 	activeKey := fmt.Sprintf(KeyActive, queueName)
 	leaseKey := fmt.Sprintf(KeyLease, queueName)
 
-	// Remove from active queue (List) and lease tracking (Sorted Set)
-	r.Rdb.LRem(ctx, activeKey, 1, taskID)
-	r.Rdb.ZRem(ctx, leaseKey, taskID)
-
-	// Delete the task hash entirely
-	r.Rdb.Del(ctx, taskKey)
+	if err := cleanupActiveCmd.Run(ctx, r.Rdb,
+		[]string{activeKey, leaseKey, taskKey},
+		taskID,
+	).Err(); err != nil {
+		return fmt.Errorf("cleanup-active script failed for task %s: %w", taskID, err)
+	}
 
 	return nil
 }
@@ -617,4 +664,194 @@ func (r *Client) IncrementFailed(ctx context.Context, queueName string) error {
 	pipe.Incr(ctx, dailyKey)
 	_, err := pipe.Exec(ctx)
 	return err
+}
+
+// --- Lease recovery methods ---
+
+// ListLeaseExpired returns task IDs with expired leases for a given queue.
+// cutoff is the time threshold: tasks with lease score <= cutoff are considered expired.
+func (r *Client) ListLeaseExpired(ctx context.Context, queueName string, cutoff time.Time) ([]*TaskData, error) {
+	leaseKey := fmt.Sprintf(KeyLease, queueName)
+
+	ids, err := r.Rdb.ZRangeByScore(ctx, leaseKey, &redis.ZRangeBy{
+		Min: "-inf",
+		Max: fmt.Sprintf("%d", cutoff.Unix()),
+	}).Result()
+	if err != nil {
+		return nil, fmt.Errorf("zrangebyscore failed for lease key %s: %w", leaseKey, err)
+	}
+
+	var tasks []*TaskData
+	for _, taskID := range ids {
+		taskKey := fmt.Sprintf(KeyTask, queueName, taskID)
+		data, err := r.Rdb.HGetAll(ctx, taskKey).Result()
+		if err != nil || len(data) == 0 {
+			// Orphaned lease entry — task hash deleted. Return with zero MaxRetry so recoverer archives it.
+			tasks = append(tasks, &TaskData{
+				ID:      taskID,
+				Queue:   queueName,
+				TaskKey: taskKey,
+			})
+			continue
+		}
+
+		// Parse task data
+		var maxRetry, retried int
+		var taskType string
+		if msgData, ok := data[FieldMsg]; ok {
+			if asynqMsg, err := parseAsynqMessage([]byte(msgData)); err == nil {
+				taskType = asynqMsg.Type
+				maxRetry = asynqMsg.MaxRetry
+				retried = asynqMsg.Retried
+			}
+		}
+		// Hash field overrides protobuf for retried count
+		if retriedStr, ok := data[FieldRetried]; ok {
+			var hashRetried int
+			if _, err := fmt.Sscanf(retriedStr, "%d", &hashRetried); err == nil && hashRetried > retried {
+				retried = hashRetried
+			}
+		}
+
+		tasks = append(tasks, &TaskData{
+			ID:       taskID,
+			Type:     taskType,
+			Retry:    retried,
+			MaxRetry: maxRetry,
+			Queue:    queueName,
+			TaskKey:  taskKey,
+		})
+	}
+
+	return tasks, nil
+}
+
+// recoverToRetryCmd atomically removes from active/lease and adds to retry sorted set.
+var recoverToRetryCmd = redis.NewScript(`
+redis.call("LREM", KEYS[1], 0, ARGV[1])
+redis.call("ZREM", KEYS[2], ARGV[1])
+redis.call("ZADD", KEYS[3], ARGV[2], ARGV[1])
+redis.call("HINCRBY", KEYS[4], "retried", 1)
+redis.call("HSET", KEYS[4], "state", "retry", "error_msg", "lease expired", "last_failed_at", ARGV[3])
+return 1
+`)
+
+// RecoverToRetry moves an expired-lease task from active to retry with a delay.
+func (r *Client) RecoverToRetry(ctx context.Context, task *TaskData, queueName string, delay time.Duration) error {
+	activeKey := fmt.Sprintf(KeyActive, queueName)
+	leaseKey := fmt.Sprintf(KeyLease, queueName)
+	retryKey := fmt.Sprintf(KeyRetry, queueName)
+	taskKey := fmt.Sprintf(KeyTask, queueName, task.ID)
+
+	now := time.Now()
+	retryAt := float64(now.Add(delay).Unix())
+
+	if err := recoverToRetryCmd.Run(ctx, r.Rdb,
+		[]string{activeKey, leaseKey, retryKey, taskKey},
+		task.ID, retryAt, now.Unix(),
+	).Err(); err != nil {
+		return fmt.Errorf("recover-to-retry script failed for task %s: %w", task.ID, err)
+	}
+	return nil
+}
+
+// recoverToArchiveCmd atomically removes from active/lease and archives a task.
+var recoverToArchiveCmd = redis.NewScript(`
+redis.call("LREM", KEYS[1], 0, ARGV[1])
+redis.call("ZREM", KEYS[2], ARGV[1])
+redis.call("ZADD", KEYS[3], ARGV[2], ARGV[1])
+redis.call("HSET", KEYS[4], "state", "archived", "error_msg", "lease expired: max retries exceeded", "last_failed_at", ARGV[2])
+return 1
+`)
+
+// RecoverToArchive moves an expired-lease task from active to archived.
+func (r *Client) RecoverToArchive(ctx context.Context, task *TaskData, queueName string) error {
+	activeKey := fmt.Sprintf(KeyActive, queueName)
+	leaseKey := fmt.Sprintf(KeyLease, queueName)
+	archivedKey := fmt.Sprintf(KeyArchived, queueName)
+	taskKey := fmt.Sprintf(KeyTask, queueName, task.ID)
+
+	now := time.Now().Unix()
+
+	if err := recoverToArchiveCmd.Run(ctx, r.Rdb,
+		[]string{activeKey, leaseKey, archivedKey, taskKey},
+		task.ID, now,
+	).Err(); err != nil {
+		return fmt.Errorf("recover-to-archive script failed for task %s: %w", task.ID, err)
+	}
+	return nil
+}
+
+// recoverOrphanedCmd removes orphaned entries from active list and lease set (no task hash to update).
+var recoverOrphanedCmd = redis.NewScript(`
+redis.call("LREM", KEYS[1], 0, ARGV[1])
+redis.call("ZREM", KEYS[2], ARGV[1])
+return 1
+`)
+
+// RecoverOrphaned removes an orphaned task (no hash data) from active and lease.
+func (r *Client) RecoverOrphaned(ctx context.Context, taskID string, queueName string) error {
+	activeKey := fmt.Sprintf(KeyActive, queueName)
+	leaseKey := fmt.Sprintf(KeyLease, queueName)
+
+	if err := recoverOrphanedCmd.Run(ctx, r.Rdb,
+		[]string{activeKey, leaseKey},
+		taskID,
+	).Err(); err != nil {
+		return fmt.Errorf("recover-orphaned script failed for task %s: %w", taskID, err)
+	}
+	return nil
+}
+
+// ExtendLease renews the lease of an in-flight task, pushing its expiration to
+// now+leaseDuration. It uses ZADD with XX so a task whose lease was already
+// removed (e.g. it just completed) is NOT re-added — this avoids resurrecting a
+// finished task's lease entry. Safe to call on the shared per-sub-queue lease key
+// from multiple workers, since each only extends its own task IDs.
+func (r *Client) ExtendLease(ctx context.Context, taskID, queueName string, leaseDuration time.Duration) error {
+	if leaseDuration <= 0 {
+		leaseDuration = 2 * time.Minute
+	}
+	leaseKey := fmt.Sprintf(KeyLease, queueName)
+	expiration := float64(time.Now().Add(leaseDuration).Unix())
+	if err := r.Rdb.ZAddArgs(ctx, leaseKey, redis.ZAddArgs{
+		XX:      true,
+		Members: []redis.Z{{Score: expiration, Member: taskID}},
+	}).Err(); err != nil {
+		return fmt.Errorf("extend-lease failed for task %s: %w", taskID, err)
+	}
+	return nil
+}
+
+// requeueActiveCmd moves a SINGLE task from active back to pending, but only if it
+// is actually still in the active list. It never touches other tasks, so it is safe
+// on the shared per-sub-queue active/lease keys when multiple workers run.
+// Returns the number of entries removed from active (0 if the task was no longer active).
+var requeueActiveCmd = redis.NewScript(`
+local removed = redis.call("LREM", KEYS[1], 0, ARGV[1])
+if removed > 0 then
+    redis.call("ZREM", KEYS[2], ARGV[1])
+    redis.call("LPUSH", KEYS[3], ARGV[1])
+    redis.call("HSET", KEYS[4], "state", "pending")
+end
+return removed
+`)
+
+// RequeueActive moves one task from the active list back to pending (and clears its
+// lease) if it is still active. Used on graceful shutdown to requeue this worker's
+// own in-flight tasks without disturbing tasks owned by other workers.
+func (r *Client) RequeueActive(ctx context.Context, taskID, queueName string) (int, error) {
+	activeKey := fmt.Sprintf(KeyActive, queueName)
+	leaseKey := fmt.Sprintf(KeyLease, queueName)
+	pendingKey := fmt.Sprintf(KeyPending, queueName)
+	taskKey := fmt.Sprintf(KeyTask, queueName, taskID)
+
+	removed, err := requeueActiveCmd.Run(ctx, r.Rdb,
+		[]string{activeKey, leaseKey, pendingKey, taskKey},
+		taskID,
+	).Int()
+	if err != nil {
+		return 0, fmt.Errorf("requeue-active script failed for task %s: %w", taskID, err)
+	}
+	return removed, nil
 }

--- a/lease_recoverer.go
+++ b/lease_recoverer.go
@@ -1,0 +1,171 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	iredis "github.com/publikey/runqy-worker/internal/redis"
+)
+
+// leaseRecoverer periodically scans the lease sorted sets for tasks with expired leases
+// and recovers them (retry or archive). This handles cases where a worker crashes or
+// is killed without properly cleaning up its active tasks.
+type leaseRecoverer struct {
+	redis    *redisClient
+	redisMu  *sync.RWMutex // shared lock from processor for redis client swaps
+	queues   []string
+	interval time.Duration
+	logger   Logger
+
+	done chan struct{}
+	wg   sync.WaitGroup
+}
+
+// newLeaseRecoverer creates a new lease recoverer.
+// interval controls how often the lease sorted sets are scanned (default 60s).
+func newLeaseRecoverer(rdb *redisClient, redisMu *sync.RWMutex, queues []string, interval time.Duration, logger Logger) *leaseRecoverer {
+	if interval <= 0 {
+		interval = 60 * time.Second
+	}
+	return &leaseRecoverer{
+		redis:    rdb,
+		redisMu:  redisMu,
+		queues:   queues,
+		interval: interval,
+		logger:   logger,
+		done:     make(chan struct{}),
+	}
+}
+
+// start begins the recovery loop.
+func (lr *leaseRecoverer) start() {
+	lr.wg.Add(1)
+	go lr.loop()
+}
+
+// stop signals the recoverer to stop and waits for it to finish.
+func (lr *leaseRecoverer) stop() {
+	close(lr.done)
+	lr.wg.Wait()
+}
+
+// updateClient updates the Redis client after reconnection.
+func (lr *leaseRecoverer) updateClient(rdb *redisClient) {
+	lr.redis = rdb
+}
+
+func (lr *leaseRecoverer) loop() {
+	defer lr.wg.Done()
+
+	ticker := time.NewTicker(lr.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-lr.done:
+			return
+		case <-ticker.C:
+			lr.recover()
+		}
+	}
+}
+
+func (lr *leaseRecoverer) recover() {
+	lr.redisMu.RLock()
+	rdb := lr.redis
+	lr.redisMu.RUnlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// 30-second buffer to accommodate clock skew (same as asynq's recoverer)
+	cutoff := time.Now().Add(-30 * time.Second)
+
+	// Deduplicate queues (buildQueueList may repeat queues for weighting)
+	seen := make(map[string]bool, len(lr.queues))
+	for _, q := range lr.queues {
+		if seen[q] {
+			continue
+		}
+		seen[q] = true
+
+		lr.recoverQueue(ctx, rdb, q, cutoff)
+	}
+}
+
+func (lr *leaseRecoverer) recoverQueue(ctx context.Context, rdb *redisClient, queue string, cutoff time.Time) {
+	tasks, err := rdb.listLeaseExpired(ctx, queue, cutoff)
+	if err != nil {
+		lr.logger.Error("Lease recoverer: failed to list expired for queue %s: %v", queue, err)
+		return
+	}
+
+	for _, task := range tasks {
+		lr.recoverTask(ctx, rdb, task, queue)
+	}
+}
+
+func (lr *leaseRecoverer) recoverTask(ctx context.Context, rdb *redisClient, task *iredis.TaskData, queue string) {
+	// Orphaned task (hash deleted) — just clean up active + lease
+	if task.Type == "" && task.MaxRetry == 0 && task.Retry == 0 {
+		if err := rdb.recoverOrphaned(ctx, task.ID, queue); err != nil {
+			lr.logger.Error("Lease recoverer: failed to clean orphaned task %s: %v", task.ID, err)
+		} else {
+			lr.logger.Warn("Lease recoverer: cleaned orphaned task %s (queue=%s)", task.ID, queue)
+		}
+		return
+	}
+
+	if task.Retry < task.MaxRetry {
+		// Retry with exponential backoff based on retry count
+		delay := defaultRecoverRetryDelay(task.Retry + 1)
+		if err := rdb.recoverToRetry(ctx, task, queue, delay); err != nil {
+			lr.logger.Error("Lease recoverer: failed to retry task %s: %v", task.ID, err)
+		} else {
+			lr.logger.Warn("Lease recoverer: recovered task %s to retry (queue=%s, attempt=%d/%d)",
+				task.ID, queue, task.Retry+1, task.MaxRetry)
+		}
+	} else {
+		if err := rdb.recoverToArchive(ctx, task, queue); err != nil {
+			lr.logger.Error("Lease recoverer: failed to archive task %s: %v", task.ID, err)
+		} else {
+			lr.logger.Warn("Lease recoverer: archived expired task %s (queue=%s, max retries exceeded)",
+				task.ID, queue)
+		}
+		// Increment failed counter
+		if err := rdb.incrementFailed(ctx, queue); err != nil {
+			lr.logger.Error("Lease recoverer: failed to increment failed counter for queue %s: %v", queue, err)
+		}
+	}
+}
+
+// defaultRecoverRetryDelay returns a simple exponential backoff delay for recovered tasks.
+func defaultRecoverRetryDelay(n int) time.Duration {
+	// 15s, 30s, 60s, 120s, ... capped at 10 minutes
+	delay := time.Duration(15<<uint(n-1)) * time.Second
+	if delay > 10*time.Minute {
+		delay = 10 * time.Minute
+	}
+	return delay
+}
+
+// recoverActiveOnShutdown requeues this worker's own remaining in-flight tasks back
+// to pending. It operates strictly on the given taskID -> queue map, so it never
+// disturbs tasks owned by OTHER workers sharing the same per-sub-queue active/lease
+// keys. Should be called during graceful shutdown, after the processor has stopped.
+func recoverActiveOnShutdown(ctx context.Context, rdb *redisClient, inflight map[string]string, logger Logger) {
+	recovered := 0
+	for taskID, queueName := range inflight {
+		n, err := rdb.requeueActive(ctx, taskID, queueName)
+		if err != nil {
+			logger.Error("Shutdown recovery: failed to requeue task %s (queue=%s): %v", taskID, queueName, err)
+			continue
+		}
+		recovered += n
+	}
+	if recovered > 0 {
+		logger.Info(fmt.Sprintf("Shutdown recovery: moved %d active task(s) back to pending", recovered))
+	}
+}

--- a/processor.go
+++ b/processor.go
@@ -27,6 +27,15 @@ type processor struct {
 	cancel    context.CancelFunc
 	wg        sync.WaitGroup
 	logger    Logger
+
+	// In-flight tasks owned by this processor (taskID -> sub-queue name).
+	// Used to renew leases while processing and to requeue leftovers on shutdown.
+	inflight   map[string]string
+	inflightMu sync.Mutex
+
+	// Lease extender lifecycle.
+	leaseDone chan struct{}
+	leaseWg   sync.WaitGroup
 }
 
 // newProcessor creates a new processor.
@@ -43,7 +52,34 @@ func newProcessor(rdb *redisClient, handler Handler, cfg Config) *processor {
 		done:          make(chan struct{}),
 		stopping:      make(chan struct{}),
 		logger:        cfg.Logger,
+		inflight:      make(map[string]string),
+		leaseDone:     make(chan struct{}),
 	}
+}
+
+// trackInflight records a task as in-flight (owned by this processor).
+func (p *processor) trackInflight(taskID, queueName string) {
+	p.inflightMu.Lock()
+	p.inflight[taskID] = queueName
+	p.inflightMu.Unlock()
+}
+
+// untrackInflight removes a task from the in-flight set.
+func (p *processor) untrackInflight(taskID string) {
+	p.inflightMu.Lock()
+	delete(p.inflight, taskID)
+	p.inflightMu.Unlock()
+}
+
+// snapshotInflight returns a copy of the current in-flight tasks (taskID -> queue).
+func (p *processor) snapshotInflight() map[string]string {
+	p.inflightMu.Lock()
+	defer p.inflightMu.Unlock()
+	out := make(map[string]string, len(p.inflight))
+	for k, v := range p.inflight {
+		out[k] = v
+	}
+	return out
 }
 
 // SetQueueHandler sets the handler for a specific queue.
@@ -95,6 +131,52 @@ func (p *processor) start() {
 		p.wg.Add(1)
 		go p.worker(i)
 	}
+	// Renew leases of in-flight tasks so a live worker keeps ownership while a
+	// dead worker's leases expire and become recoverable.
+	p.leaseWg.Add(1)
+	go p.leaseExtenderLoop()
+}
+
+// leaseExtenderLoop periodically renews the leases of all in-flight tasks.
+func (p *processor) leaseExtenderLoop() {
+	defer p.leaseWg.Done()
+
+	interval := p.config.LeaseExtendInterval
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.leaseDone:
+			return
+		case <-ticker.C:
+			p.extendInflightLeases()
+		}
+	}
+}
+
+// extendInflightLeases renews the lease for every currently in-flight task.
+func (p *processor) extendInflightLeases() {
+	snapshot := p.snapshotInflight()
+	if len(snapshot) == 0 {
+		return
+	}
+
+	p.redisMu.RLock()
+	rdb := p.redis
+	p.redisMu.RUnlock()
+
+	leaseDuration := p.config.LeaseDuration
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	for taskID, queueName := range snapshot {
+		if err := rdb.extendLease(ctx, taskID, queueName, leaseDuration); err != nil {
+			p.logger.Warn("Failed to extend lease for task %s (queue=%s): %v", taskID, queueName, err)
+		}
+	}
 }
 
 // stop gracefully stops all workers.
@@ -125,6 +207,12 @@ func (p *processor) stop() {
 		p.cancel()
 		p.wg.Wait()
 	}
+
+	// Phase 4: Stop the lease extender now that no task goroutines remain.
+	// Any task left in-flight here was force-cancelled; the caller requeues it
+	// via snapshotInflight(), and its lease will no longer be renewed.
+	close(p.leaseDone)
+	p.leaseWg.Wait()
 }
 
 // worker is a single worker goroutine.
@@ -157,7 +245,7 @@ func (p *processor) processOne(ctx context.Context) {
 	p.redisMu.RUnlock()
 
 	// Dequeue a task
-	task, err := redisClient.dequeue(ctx, p.queues)
+	task, err := redisClient.dequeue(ctx, p.queues, p.config.LeaseDuration)
 	if err != nil {
 		p.logger.Error("Dequeue error: %v", err)
 
@@ -189,6 +277,11 @@ func (p *processor) processOne(ctx context.Context) {
 	}
 
 	queueName := task.queue
+
+	// Track as in-flight: the lease extender renews its lease while it runs, and
+	// graceful shutdown can requeue it if it doesn't finish. Untracked by the
+	// terminal handlers (handleSuccess/handleError) below.
+	p.trackInflight(task.id, queueName)
 
 	// Extract parent queue for supervisor health check (sub-queue -> parent)
 	parentQueue := parentQueueName(queueName)
@@ -226,6 +319,13 @@ func (p *processor) processOne(ctx context.Context) {
 	}
 
 	if err != nil {
+		// If the processor is shutting down (context cancelled), the error is just
+		// cancellation, not a real task failure. Leave the task in-flight (still in
+		// active/lease) so the graceful-shutdown requeue moves it back to pending
+		// without counting a retry.
+		if ctx.Err() != nil {
+			return
+		}
 		p.handleError(ctx, task, queueName, err)
 	} else {
 		p.handleSuccess(ctx, task, queueName)
@@ -251,6 +351,13 @@ func (p *processor) redisRetry(operation string, taskID string, fn func() error)
 
 // handleSuccess handles successful task completion.
 func (p *processor) handleSuccess(ctx context.Context, task *Task, queueName string) {
+	defer p.untrackInflight(task.id)
+
+	// Use a detached context so completion bookkeeping persists even if the
+	// processor context was cancelled during shutdown.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	// Check if redis storage is enabled for this queue
 	storeInRedis := true
 	if state, ok := p.subQueueToState[queueName]; ok {
@@ -275,7 +382,14 @@ func (p *processor) handleSuccess(ctx context.Context, task *Task, queueName str
 
 // handleError handles task processing errors.
 func (p *processor) handleError(ctx context.Context, task *Task, queueName string, err error) {
+	defer p.untrackInflight(task.id)
+
 	p.logger.Error(fmt.Sprintf("Task %s failed: %v", task.id, err))
+
+	// Use a detached context so retry/fail bookkeeping persists even if the
+	// processor context was cancelled during shutdown.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
 	// Check if redis storage is enabled for this queue
 	storeInRedis := true

--- a/redis.go
+++ b/redis.go
@@ -34,9 +34,10 @@ func newRedisClient(rdb *goredis.Client, logger Logger) *redisClient {
 }
 
 // dequeue attempts to dequeue a task from the given queues.
+// leaseDuration sets the initial lease validity for the dequeued task.
 // Returns nil if no task is available.
-func (r *redisClient) dequeue(ctx context.Context, queues []string) (*Task, error) {
-	taskData, err := r.internal.Dequeue(ctx, queues)
+func (r *redisClient) dequeue(ctx context.Context, queues []string, leaseDuration time.Duration) (*Task, error) {
+	taskData, err := r.internal.Dequeue(ctx, queues, leaseDuration)
 	if err != nil {
 		return nil, err
 	}
@@ -112,4 +113,34 @@ func (r *redisClient) incrementProcessed(ctx context.Context, queueName string) 
 // incrementFailed increments the failed counters for a queue.
 func (r *redisClient) incrementFailed(ctx context.Context, queueName string) error {
 	return r.internal.IncrementFailed(ctx, queueName)
+}
+
+// listLeaseExpired returns tasks with expired leases for a given queue.
+func (r *redisClient) listLeaseExpired(ctx context.Context, queueName string, cutoff time.Time) ([]*redis.TaskData, error) {
+	return r.internal.ListLeaseExpired(ctx, queueName, cutoff)
+}
+
+// recoverToRetry moves an expired-lease task to retry with delay.
+func (r *redisClient) recoverToRetry(ctx context.Context, task *redis.TaskData, queueName string, delay time.Duration) error {
+	return r.internal.RecoverToRetry(ctx, task, queueName, delay)
+}
+
+// recoverToArchive moves an expired-lease task to archived.
+func (r *redisClient) recoverToArchive(ctx context.Context, task *redis.TaskData, queueName string) error {
+	return r.internal.RecoverToArchive(ctx, task, queueName)
+}
+
+// recoverOrphaned removes an orphaned task from active and lease.
+func (r *redisClient) recoverOrphaned(ctx context.Context, taskID string, queueName string) error {
+	return r.internal.RecoverOrphaned(ctx, taskID, queueName)
+}
+
+// extendLease renews the lease of an in-flight task.
+func (r *redisClient) extendLease(ctx context.Context, taskID, queueName string, leaseDuration time.Duration) error {
+	return r.internal.ExtendLease(ctx, taskID, queueName, leaseDuration)
+}
+
+// requeueActive moves a single in-flight task from active back to pending (if still active).
+func (r *redisClient) requeueActive(ctx context.Context, taskID, queueName string) (int, error) {
+	return r.internal.RequeueActive(ctx, taskID, queueName)
 }

--- a/worker.go
+++ b/worker.go
@@ -33,14 +33,15 @@ type QueueState struct {
 
 // Worker processes tasks from Redis queues.
 type Worker struct {
-	config        Config
-	rdb           *redis.Client
-	mux           *ServeMux
-	processor     *processor
-	heartbeat     *heartbeat
-	forwarder     *retryForwarder
-	reconnector   *redisReconnector
-	queueHandlers map[string]HandlerFunc // stored until processor is created
+	config         Config
+	rdb            *redis.Client
+	mux            *ServeMux
+	processor      *processor
+	heartbeat      *heartbeat
+	forwarder      *retryForwarder
+	leaseRecoverer *leaseRecoverer
+	reconnector    *redisReconnector
+	queueHandlers  map[string]HandlerFunc // stored until processor is created
 
 	// Multi-queue bootstrap state
 	queueStates  map[string]*QueueState
@@ -640,6 +641,9 @@ func (w *Worker) Run() error {
 	// Create retry forwarder — scans retry sorted sets and moves ready tasks to pending
 	w.forwarder = newRetryForwarder(redisClient, &w.processor.redisMu, w.processor.queues, 5*time.Second, w.logger)
 
+	// Create lease recoverer — scans lease sorted sets for expired tasks and recovers them
+	w.leaseRecoverer = newLeaseRecoverer(redisClient, &w.processor.redisMu, w.processor.queues, 60*time.Second, w.logger)
+
 	// Set queue states for per-queue health checks
 	w.processor.SetQueueStates(w.queueStates)
 
@@ -656,8 +660,9 @@ func (w *Worker) Run() error {
 			w.rdb = client
 			w.heartbeat.updateClient(client)
 			w.processor.updateClient(client, w.logger)
-			// Update forwarder's redis client under the shared lock
+			// Update forwarder's and recoverer's redis client under the shared lock
 			w.forwarder.updateClient(newRedisClient(client, w.logger))
+			w.leaseRecoverer.updateClient(newRedisClient(client, w.logger))
 		})
 		w.processor.SetReconnector(w.reconnector)
 	} else {
@@ -670,6 +675,7 @@ func (w *Worker) Run() error {
 	}
 	w.processor.start()
 	w.forwarder.start()
+	w.leaseRecoverer.start()
 
 	w.logger.Info("Worker running. Press Ctrl+C to stop.")
 
@@ -724,6 +730,9 @@ func (w *Worker) Start(ctx context.Context) error {
 	// Create retry forwarder — scans retry sorted sets and moves ready tasks to pending
 	w.forwarder = newRetryForwarder(redisClient, &w.processor.redisMu, w.processor.queues, 5*time.Second, w.logger)
 
+	// Create lease recoverer — scans lease sorted sets for expired tasks and recovers them
+	w.leaseRecoverer = newLeaseRecoverer(redisClient, &w.processor.redisMu, w.processor.queues, 60*time.Second, w.logger)
+
 	// Set queue states for per-queue health checks
 	w.processor.SetQueueStates(w.queueStates)
 
@@ -741,6 +750,7 @@ func (w *Worker) Start(ctx context.Context) error {
 			w.heartbeat.updateClient(client)
 			w.processor.updateClient(client, w.logger)
 			w.forwarder.updateClient(newRedisClient(client, w.logger))
+			w.leaseRecoverer.updateClient(newRedisClient(client, w.logger))
 		})
 		w.processor.SetReconnector(w.reconnector)
 	} else {
@@ -753,6 +763,7 @@ func (w *Worker) Start(ctx context.Context) error {
 	}
 	w.processor.start()
 	w.forwarder.start()
+	w.leaseRecoverer.start()
 
 	w.logger.Info("Worker running.")
 
@@ -779,6 +790,11 @@ func (w *Worker) Shutdown() {
 
 // shutdown performs the actual shutdown sequence.
 func (w *Worker) shutdown() error {
+	w.logger.Info("Stopping lease recoverer...")
+	if w.leaseRecoverer != nil {
+		w.leaseRecoverer.stop()
+	}
+
 	w.logger.Info("Stopping retry forwarder...")
 	if w.forwarder != nil {
 		w.forwarder.stop()
@@ -787,6 +803,21 @@ func (w *Worker) shutdown() error {
 	w.logger.Info("Stopping processor...")
 	if w.processor != nil {
 		w.processor.stop()
+	}
+
+	// Requeue THIS worker's own remaining in-flight tasks (those force-cancelled
+	// at shutdown) back to pending before closing Redis. Operating on the specific
+	// task IDs avoids disturbing tasks still being processed by other workers that
+	// share the same sub-queue's active/lease keys.
+	if w.processor != nil && w.rdb != nil {
+		inflight := w.processor.snapshotInflight()
+		if len(inflight) > 0 {
+			w.logger.Info("Recovering remaining active tasks to pending...")
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			redisClient := newRedisClient(w.rdb, w.logger)
+			recoverActiveOnShutdown(ctx, redisClient, inflight, w.logger)
+			cancel()
+		}
 	}
 
 	w.logger.Info("Stopping heartbeat...")


### PR DESCRIPTION
  - Renew in-flight task leases periodically so a killed worker's tasks expire quickly and the lease recoverer reclaims them (was a fixed 30m lease, never renewed).
  - Shorten the dequeue lease to a configurable LeaseDuration (default 2m).
  - Replace the DEL-based shutdown recovery (which wiped other workers' tasks on the shared sub-queue keys) with a targeted per-task requeue.